### PR TITLE
Use `terraform-aws-s3-log-storage` module for CloudTrail logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 
 # Module directory
 .terraform/
+.idea
+terraform-aws-cloudtrail.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+addons:
+  apt:
+    packages:
+      - git
+      - make
+      - curl
+
+install:
+  - make init
+
+script:
+  - make terraform/install
+  - make terraform/get-plugins
+  - make terraform/get-modules
+  - make terraform/lint
+  - make terraform/validate

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017 Cloud Posse, LLC
+   Copyright 2017-2018 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+SHELL := /bin/bash
+
+-include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
+
+lint:
+	$(SELF) terraform/install terraform/get-modules terraform/get-plugins terraform/lint terraform/validate

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# tf_cloudtrail
+# terraform-aws-cloudtrail [![Build Status](https://travis-ci.org/cloudposse/terraform-aws-cloudtrail.svg?branch=master)](https://travis-ci.org/cloudposse/terraform-aws-cloudtrail)
 
 Setup and manage CloudTrail
+
 
 ## Argument Reference
 
@@ -8,11 +9,12 @@ Setup and manage CloudTrail
 * `region`: (Required) AWS region. Used to find remote state.
 * `enable_logging`: Enable logging, set to `false` to Pause logging (`default = true`)
 * `enable_log_file_validation`: Create signed digest file to validated contents of logs (`default = true`)
-* `include_global_service_events`: Include evnets from global services such as IAM (`default = false`)
+* `include_global_service_events`: Include events from global services such as IAM (`default = false`)
 * `is_multi_region_trail`: Whether the trail is created in all regions or just the current region (`default = false`)
 
+
 ## Usage
-```
+```hcl
 module "cloudtrails" {
   source                        = "git::https://github.com/cloudposse/tf_cloudtrail.git?ref=tags/0.1.1"
   name                          = "${var.name}"

--- a/README.md
+++ b/README.md
@@ -1,28 +1,132 @@
 # terraform-aws-cloudtrail [![Build Status](https://travis-ci.org/cloudposse/terraform-aws-cloudtrail.svg?branch=master)](https://travis-ci.org/cloudposse/terraform-aws-cloudtrail)
 
-Setup and manage CloudTrail
+Terraform module to provision an AWS [CloudTrail](https://aws.amazon.com/cloudtrail/) and an encrypted S3 bucket with versioning to store CloudTrail logs
 
-
-## Argument Reference
-
-* `name`: (Required) Name of CloudTrail trail.
-* `region`: (Required) AWS region. Used to find remote state.
-* `enable_logging`: Enable logging, set to `false` to Pause logging (`default = true`)
-* `enable_log_file_validation`: Create signed digest file to validated contents of logs (`default = true`)
-* `include_global_service_events`: Include events from global services such as IAM (`default = false`)
-* `is_multi_region_trail`: Whether the trail is created in all regions or just the current region (`default = false`)
+https://www.terraform.io/docs/providers/aws/r/cloudtrail.html
 
 
 ## Usage
+
 ```hcl
-module "cloudtrails" {
-  source                        = "git::https://github.com/cloudposse/tf_cloudtrail.git?ref=tags/0.1.1"
-  name                          = "${var.name}"
-  stage                         = "${var.stage}"
-  namespace                     = "${var.namespace}"
+module "cloudtrail" {
+  source                        = "git::https://github.com/cloudposse/terraform-aws-cloudtrail.git?ref=master"
+  namespace                     = "cp"
+  stage                         = "prod"
+  name                          = "cluster"
+  region                        = "us-east-1"
   enable_logging                = "true"
   enable_log_file_validation    = "true"
   include_global_service_events = "false"
   is_multi_region_trail         = "false"
 }
 ```
+
+## Variables
+
+|  Name                            |  Default             |  Description                                                                                       | Required |
+|:---------------------------------|:--------------------:|:---------------------------------------------------------------------------------------------------|:--------:|
+| `namespace`                      | ``                   | Namespace (e.g. `cp` or `cloudposse`)                                                              | Yes      |
+| `stage`                          | ``                   | Stage (e.g. `prod`, `dev`, `staging`)                                                              | Yes      |
+| `name`                           | ``                   | Name  (e.g. `cluster` or `app`)                                                                    | Yes      |
+| `region`                         | `us-east-1`          | AWS Region for S3 bucket to store CloudTrail logs                                                  | Yes      |
+| `attributes`                     | `[]`                 | Additional attributes (e.g. `logs`)                                                                | No       |
+| `tags`                           | `{}`                 | Additional tags  (e.g. `map("BusinessUnit","XYZ")`                                                 | No       |
+| `delimiter`                      | `-`                  | Delimiter to be used between `namespace`, `stage`, `name` and `attributes`                         | No       |
+| `acl`                            | `log-delivery-write` | Canned ACL to apply to the log storage S3 bucket                                                   | No       |
+| `enable_logging`                 | `true`               | Enable logging for the trail. Logs will be stored in the S3 bucket                                 | No       |
+| `enable_log_file_validation`     | `true`               | Specifies whether log file integrity validation is enabled. Creates signed digest for validated contents of logs    | No       |
+| `include_global_service_events`  | `false`              | Specifies whether the trail is publishing events from global services such as IAM to the log files | No       |
+| `is_multi_region_trail`          | `false`              | Specifies whether the trail is created in the current region or in all regions                     | No       |
+
+
+## Outputs
+
+| Name                      | Description                                  |
+|:--------------------------|:---------------------------------------------|
+| `bucket_name`             | S3 bucket name to store CloudTrail logs      |
+| `cloudtrail_id`           | The name of the trail                        |
+| `cloudtrail_home_region`  | The region in which the trail was created    |
+| `cloudtrail_arn`          | The Amazon Resource Name of the trail        |
+
+
+
+## Help
+
+**Got a question?**
+
+File a GitHub [issue](https://github.com/cloudposse/terraform-aws-cloudtrail/issues), send us an [email](mailto:hello@cloudposse.com) or reach out to us on [Gitter](https://gitter.im/cloudposse/).
+
+
+## Contributing
+
+### Bug Reports & Feature Requests
+
+Please use the [issue tracker](https://github.com/cloudposse/terraform-aws-cloudtrail/issues) to report any bugs or file feature requests.
+
+### Developing
+
+If you are interested in being a contributor and want to get involved in developing `terraform-aws-cloudtrail`, we would love to hear from you! Shoot us an [email](mailto:hello@cloudposse.com).
+
+In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
+
+ 1. **Fork** the repo on GitHub
+ 2. **Clone** the project to your own machine
+ 3. **Commit** changes to your own branch
+ 4. **Push** your work back up to your fork
+ 5. Submit a **Pull request** so that we can review your changes
+
+**NOTE:** Be sure to merge the latest from "upstream" before making a pull request!
+
+
+## License
+
+[APACHE 2.0](LICENSE) © 2018 [Cloud Posse, LLC](https://cloudposse.com)
+
+See [LICENSE](LICENSE) for full details.
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+## About
+
+`terraform-aws-cloudtrail` is maintained and funded by [Cloud Posse, LLC][website].
+
+![Cloud Posse](https://cloudposse.com/logo-300x69.png)
+
+
+Like it? Please let us know at <hello@cloudposse.com>
+
+We love [Open Source Software](https://github.com/cloudposse/)!
+
+See [our other projects][community]
+or [hire us][hire] to help build your next cloud platform.
+
+  [website]: https://cloudposse.com/
+  [community]: https://github.com/cloudposse/
+  [hire]: https://cloudposse.com/contact/
+
+
+### Contributors
+
+| [![Erik Osterman][erik_img]][erik_web]<br/>[Erik Osterman][erik_web] | [![Andriy Knysh][andriy_img]][andriy_web]<br/>[Andriy Knysh][andriy_web] |
+|-------------------------------------------------------|------------------------------------------------------------------|
+
+  [erik_img]: http://s.gravatar.com/avatar/88c480d4f73b813904e00a5695a454cb?s=144
+  [erik_web]: https://github.com/osterman/
+  [andriy_img]: https://avatars0.githubusercontent.com/u/7356997?v=4&u=ed9ce1c9151d552d985bdf5546772e14ef7ab617&s=144
+  [andriy_web]: https://github.com/aknysh/

--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,15 @@
-module "tf_label" {
-  source    = "git::https://github.com/cloudposse/tf_label.git?ref=tags/0.1.0"
-  namespace = "${var.namespace}"
-  stage     = "${var.stage}"
-  name      = "${var.name}"
+module "cloudtrail_label" {
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.3"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  name       = "${var.name}"
+  delimiter  = "${var.delimiter}"
+  attributes = "${var.attributes}"
+  tags       = "${var.tags}"
 }
 
 resource "aws_cloudtrail" "default" {
-  name                          = "${module.tf_label.id}"
+  name                          = "${module.cloudtrail_label.id}"
   s3_bucket_name                = "${aws_s3_bucket.default.id}"
   enable_logging                = "${var.enable_logging}"
   enable_log_file_validation    = "${var.enable_log_file_validation}"
@@ -19,7 +22,7 @@ data "aws_iam_policy_document" "default" {
     sid = "AWSCloudTrailAclCheck"
 
     principals {
-      type = "Service"
+      type        = "Service"
       identifiers = ["cloudtrail.amazonaws.com"]
     }
 
@@ -28,7 +31,7 @@ data "aws_iam_policy_document" "default" {
     ]
 
     resources = [
-      "arn:aws:s3:::${module.tf_label.id}"
+      "arn:aws:s3:::${module.cloudtrail_label.id}",
     ]
   }
 
@@ -36,7 +39,7 @@ data "aws_iam_policy_document" "default" {
     sid = "AWSCloudTrailWrite"
 
     principals {
-      type = "Service"
+      type        = "Service"
       identifiers = ["cloudtrail.amazonaws.com"]
     }
 
@@ -45,7 +48,7 @@ data "aws_iam_policy_document" "default" {
     ]
 
     resources = [
-      "arn:aws:s3:::${module.tf_label.id}/*"
+      "arn:aws:s3:::${module.cloudtrail_label.id}/*",
     ]
 
     condition {
@@ -53,15 +56,14 @@ data "aws_iam_policy_document" "default" {
       variable = "s3:x-amz-acl"
 
       values = [
-        "bucket-owner-full-control"
+        "bucket-owner-full-control",
       ]
     }
   }
 }
 
-
 resource "aws_s3_bucket" "default" {
-  bucket = "${module.tf_label.id}"
+  bucket        = "${module.cloudtrail_label.id}"
   force_destroy = false
-  policy = "${data.aws_iam_policy_document.default.json}"
+  policy        = "${data.aws_iam_policy_document.default.json}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,15 @@
 output "bucket_name" {
-  value = "${aws_s3_bucket.default.id}"
+  value = "${module.s3_log_storage.bucket_id}"
+}
+
+output "cloudtrail_id" {
+  value = "${aws_cloudtrail.default.id}"
+}
+
+output "cloudtrail_home_region" {
+  value = "${aws_cloudtrail.default.home_region}"
+}
+
+output "cloudtrail_arn" {
+  value = "${aws_cloudtrail.default.arn}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -9,20 +9,20 @@ variable "stage" {
 }
 
 variable "name" {
-  description = "Name  (e.g. `app` or `db`)"
+  description = "Name  (e.g. `app` or `cluster`)"
   type        = "string"
 }
 
 variable "delimiter" {
   type        = "string"
   default     = "-"
-  description = "Delimiter to be used between `name`, `namespace`, `stage`, etc."
+  description = "Delimiter to be used between `namespace`, `stage`, `name` and `attributes`"
 }
 
 variable "attributes" {
   type        = "list"
   default     = []
-  description = "Additional attributes (e.g. `policy` or `role`)"
+  description = "Additional attributes (e.g. `logs`)"
 }
 
 variable "tags" {
@@ -31,23 +31,34 @@ variable "tags" {
   description = "Additional tags (e.g. map('BusinessUnit`,`XYZ`)"
 }
 
+variable "acl" {
+  type        = "string"
+  description = "Canned ACL to apply to the log storage S3 bucket"
+  default     = "log-delivery-write"
+}
+
 variable "region" {
   type        = "string"
-  description = "AWS Region"
+  default     = "us-east-1"
+  description = "AWS Region for S3 bucket to store CloudTrail logs"
 }
 
 variable "enable_logging" {
-  default = "true"
+  default     = "true"
+  description = "Enable logging for the trail"
 }
 
 variable "enable_log_file_validation" {
-  default = "true"
+  default     = "true"
+  description = "Specifies whether log file integrity validation is enabled. Creates signed digest for validated contents of logs"
 }
 
 variable "is_multi_region_trail" {
-  default = "false"
+  default     = "false"
+  description = "Specifies whether the trail is created in the current region or in all regions"
 }
 
 variable "include_global_service_events" {
-  default = "false"
+  default     = "false"
+  description = "Specifies whether the trail is publishing events from global services such as IAM to the log files"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,17 +1,39 @@
-variable "region" {
-  default = ""
-}
-
-variable "name" {
-  default = "cloudtrails"
-}
-
 variable "namespace" {
-  default = ""
+  description = "Namespace (e.g. `cp` or `cloudposse`)"
+  type        = "string"
 }
 
 variable "stage" {
-  default = ""
+  description = "Stage (e.g. `prod`, `dev`, `staging`)"
+  type        = "string"
+}
+
+variable "name" {
+  description = "Name  (e.g. `app` or `db`)"
+  type        = "string"
+}
+
+variable "delimiter" {
+  type        = "string"
+  default     = "-"
+  description = "Delimiter to be used between `name`, `namespace`, `stage`, etc."
+}
+
+variable "attributes" {
+  type        = "list"
+  default     = []
+  description = "Additional attributes (e.g. `policy` or `role`)"
+}
+
+variable "tags" {
+  type        = "map"
+  default     = {}
+  description = "Additional tags (e.g. map('BusinessUnit`,`XYZ`)"
+}
+
+variable "region" {
+  type        = "string"
+  description = "AWS Region"
 }
 
 variable "enable_logging" {


### PR DESCRIPTION
## what
* Use `terraform-aws-s3-log-storage` module for CloudTrail logs
* Add `TravisCI`

## why
* `terraform-aws-s3-log-storage` provisions an S3 bucket with server-side encryption, versioning and life-cycle events (to move the logs to `Glacier`), which is what's required for CloudTrail logs
* Reuse code
* `TravisCI` to lint Terraform code and monitor build status

