### PR TITLE
Accept external S3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 # terraform-aws-cloudtrail [![Build Status](https://travis-ci.org/cloudposse/terraform-aws-cloudtrail.svg?branch=master)](https://travis-ci.org/cloudposse/terraform-aws-cloudtrail)
 
-Terraform module to provision an AWS [CloudTrail](https://aws.amazon.com/cloudtrail/) and an encrypted S3 bucket with versioning to store CloudTrail logs
+Terraform module to provision an AWS [CloudTrail](https://aws.amazon.com/cloudtrail/)
 
-https://www.terraform.io/docs/providers/aws/r/cloudtrail.html
+The module accepts an encrypted S3 bucket with versioning to store CloudTrail logs.
+
+The bucket could be from the same ASW account or from a different account.
+
+This is useful if an organization uses a number of separate AWS accounts to isolate the Audit environment from other environments (production, staging, development).
+
+In this case, you create CloudTrail in the production environment (production AWS account), 
+while the S3 bucket to store the CloudTrail logs is created in the Audit AWS account, restricting access to the logs only to the users/groups from the Audit account.
 
 
 ## Usage
@@ -13,11 +20,11 @@ module "cloudtrail" {
   namespace                     = "cp"
   stage                         = "prod"
   name                          = "cluster"
-  region                        = "us-east-1"
-  enable_logging                = "true"
   enable_log_file_validation    = "true"
   include_global_service_events = "false"
   is_multi_region_trail         = "false"
+  enable_logging                = "true"
+  s3_bucket_name                = "my-cloudtrail-logs-bucket"
 }
 ```
 
@@ -28,22 +35,20 @@ module "cloudtrail" {
 | `namespace`                      | ``                   | Namespace (e.g. `cp` or `cloudposse`)                                                              | Yes      |
 | `stage`                          | ``                   | Stage (e.g. `prod`, `dev`, `staging`)                                                              | Yes      |
 | `name`                           | ``                   | Name  (e.g. `cluster` or `app`)                                                                    | Yes      |
-| `region`                         | `us-east-1`          | AWS Region for S3 bucket to store CloudTrail logs                                                  | Yes      |
 | `attributes`                     | `[]`                 | Additional attributes (e.g. `logs`)                                                                | No       |
 | `tags`                           | `{}`                 | Additional tags  (e.g. `map("BusinessUnit","XYZ")`                                                 | No       |
 | `delimiter`                      | `-`                  | Delimiter to be used between `namespace`, `stage`, `name` and `attributes`                         | No       |
-| `acl`                            | `log-delivery-write` | Canned ACL to apply to the log storage S3 bucket                                                   | No       |
-| `enable_logging`                 | `true`               | Enable logging for the trail. Logs will be stored in the S3 bucket                                 | No       |
 | `enable_log_file_validation`     | `true`               | Specifies whether log file integrity validation is enabled. Creates signed digest for validated contents of logs    | No       |
 | `include_global_service_events`  | `false`              | Specifies whether the trail is publishing events from global services such as IAM to the log files | No       |
 | `is_multi_region_trail`          | `false`              | Specifies whether the trail is created in the current region or in all regions                     | No       |
+| `enable_logging`                 | `true`               | Enable logging for the trail. Logs will be stored in the S3 bucket                                 | No       |
+| `s3_bucket_name`                 | ``                   | S3 bucket name for CloudTrail logs                                                                 | Yes (if `enable_logging`=`true`)  |
 
 
 ## Outputs
 
 | Name                      | Description                                  |
 |:--------------------------|:---------------------------------------------|
-| `bucket_name`             | S3 bucket name to store CloudTrail logs      |
 | `cloudtrail_id`           | The name of the trail                        |
 | `cloudtrail_home_region`  | The region in which the trail was created    |
 | `cloudtrail_arn`          | The Amazon Resource Name of the trail        |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # terraform-aws-cloudtrail [![Build Status](https://travis-ci.org/cloudposse/terraform-aws-cloudtrail.svg?branch=master)](https://travis-ci.org/cloudposse/terraform-aws-cloudtrail)
 
-Terraform module to provision an AWS [CloudTrail](https://aws.amazon.com/cloudtrail/)
+Terraform module to provision an AWS [CloudTrail](https://aws.amazon.com/cloudtrail/).
 
 The module accepts an encrypted S3 bucket with versioning to store CloudTrail logs.
 
@@ -18,15 +18,44 @@ while the S3 bucket to store the CloudTrail logs is created in the Audit AWS acc
 module "cloudtrail" {
   source                        = "git::https://github.com/cloudposse/terraform-aws-cloudtrail.git?ref=master"
   namespace                     = "cp"
-  stage                         = "prod"
+  stage                         = "dev"
   name                          = "cluster"
   enable_log_file_validation    = "true"
-  include_global_service_events = "false"
+  include_global_service_events = "true"
   is_multi_region_trail         = "false"
   enable_logging                = "true"
   s3_bucket_name                = "my-cloudtrail-logs-bucket"
 }
 ```
+
+__NOTE:__ To create an S3 bucket for CloudTrail logs, use [terraform-aws-cloudtrail-s3-bucket](https://github.com/cloudposse/terraform-aws-cloudtrail-s3-bucket) module.
+It creates an S3 bucket and an IAM policy to allow CloudTrail logs.
+
+
+```hcl
+module "cloudtrail" {
+  source                        = "git::https://github.com/cloudposse/terraform-aws-cloudtrail.git?ref=master"
+  namespace                     = "cp"
+  stage                         = "dev"
+  name                          = "cluster"
+  enable_log_file_validation    = "true"
+  include_global_service_events = "true"
+  is_multi_region_trail         = "false"
+  enable_logging                = "true"
+  s3_bucket_name                = "${module.cloudtrail_s3_bucket.bucket_id}"
+}
+
+module "cloudtrail_s3_bucket" {
+  source    = "git::https://github.com/cloudposse/terraform-aws-cloudtrail-s3-bucket.git?ref=master"
+  namespace = "cp"
+  stage     = "dev"
+  name      = "cluster"
+  region    = "us-east-1"
+}
+```
+
+For a complete example, see [examples/complete](examples/complete).
+
 
 ## Variables
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,0 +1,19 @@
+module "cloudtrail" {
+  source                        = "git::https://github.com/cloudposse/terraform-aws-cloudtrail.git?ref=master"
+  namespace                     = "cp"
+  stage                         = "dev"
+  name                          = "cluster"
+  enable_logging                = "true"
+  enable_log_file_validation    = "true"
+  include_global_service_events = "true"
+  is_multi_region_trail         = "false"
+  s3_bucket_name                = "${module.cloudtrail_s3_bucket.bucket_id}"
+}
+
+module "cloudtrail_s3_bucket" {
+  source    = "git::https://github.com/cloudposse/terraform-aws-cloudtrail-s3-bucket.git?ref=master"
+  namespace = "cp"
+  stage     = "dev"
+  name      = "cluster"
+  region    = "us-east-1"
+}

--- a/main.tf
+++ b/main.tf
@@ -10,72 +10,10 @@ module "cloudtrail_label" {
 
 resource "aws_cloudtrail" "default" {
   name                          = "${module.cloudtrail_label.id}"
-  s3_bucket_name                = "${module.s3_log_storage.bucket_id}"
   enable_logging                = "${var.enable_logging}"
+  s3_bucket_name                = "${var.s3_bucket_name}"
   enable_log_file_validation    = "${var.enable_log_file_validation}"
   is_multi_region_trail         = "${var.is_multi_region_trail}"
   include_global_service_events = "${var.include_global_service_events}"
   tags                          = "${module.cloudtrail_label.tags}"
-}
-
-data "aws_iam_policy_document" "default" {
-  statement {
-    sid = "AWSCloudTrailAclCheck"
-
-    principals {
-      type        = "Service"
-      identifiers = ["cloudtrail.amazonaws.com"]
-    }
-
-    actions = [
-      "s3:GetBucketAcl",
-    ]
-
-    resources = [
-      "arn:aws:s3:::${module.cloudtrail_label.id}",
-    ]
-  }
-
-  statement {
-    sid = "AWSCloudTrailWrite"
-
-    principals {
-      type        = "Service"
-      identifiers = ["cloudtrail.amazonaws.com"]
-    }
-
-    actions = [
-      "s3:PutObject",
-    ]
-
-    resources = [
-      "arn:aws:s3:::${module.cloudtrail_label.id}/*",
-    ]
-
-    condition {
-      test     = "StringEquals"
-      variable = "s3:x-amz-acl"
-
-      values = [
-        "bucket-owner-full-control",
-      ]
-    }
-  }
-}
-
-# https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html
-module "s3_log_storage" {
-  source                 = "git::https://github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.2.0"
-  namespace              = "${var.namespace}"
-  stage                  = "${var.stage}"
-  name                   = "${var.name}"
-  region                 = "${var.region}"
-  acl                    = "${var.acl}"
-  policy                 = "${data.aws_iam_policy_document.default.json}"
-  force_destroy          = "false"
-  versioning_enabled     = "true"
-  lifecycle_rule_enabled = "false"
-  delimiter              = "${var.delimiter}"
-  attributes             = ["${compact(concat(var.attributes, list("cloudtrail", "logs")))}"]
-  tags                   = "${var.tags}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,3 @@
-output "bucket_name" {
-  value = "${module.s3_log_storage.bucket_id}"
-}
-
 output "cloudtrail_id" {
   value = "${aws_cloudtrail.default.id}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -31,23 +31,6 @@ variable "tags" {
   description = "Additional tags (e.g. map('BusinessUnit`,`XYZ`)"
 }
 
-variable "acl" {
-  type        = "string"
-  description = "Canned ACL to apply to the log storage S3 bucket"
-  default     = "log-delivery-write"
-}
-
-variable "region" {
-  type        = "string"
-  default     = "us-east-1"
-  description = "AWS Region for S3 bucket to store CloudTrail logs"
-}
-
-variable "enable_logging" {
-  default     = "true"
-  description = "Enable logging for the trail"
-}
-
 variable "enable_log_file_validation" {
   default     = "true"
   description = "Specifies whether log file integrity validation is enabled. Creates signed digest for validated contents of logs"
@@ -61,4 +44,14 @@ variable "is_multi_region_trail" {
 variable "include_global_service_events" {
   default     = "false"
   description = "Specifies whether the trail is publishing events from global services such as IAM to the log files"
+}
+
+variable "enable_logging" {
+  default     = "true"
+  description = "Enable logging for the trail"
+}
+
+variable "s3_bucket_name" {
+  type        = "string"
+  description = "S3 bucket name for CloudTrail logs"
 }


### PR DESCRIPTION
## what
Accept external S3 bucket

## why
The bucket could be from the same ASW account or from a different account.

This is useful if an organization uses a number of separate AWS accounts to isolate the Audit environment from other environments (production, staging, development).

In this case, you create CloudTrail in the production environment (production AWS account), 
while the S3 bucket to store the CloudTrail logs is created in the Audit AWS account, restricting access to the logs only to the users/groups from the Audit account.
