### PR TITLE
Add cloudwatch logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,11 @@ For a complete example, see [examples/complete](examples/complete).
 | `include_global_service_events`  | `false`              | Specifies whether the trail is publishing events from global services such as IAM to the log files | No       |
 | `is_multi_region_trail`          | `false`              | Specifies whether the trail is created in the current region or in all regions                     | No       |
 | `enable_logging`                 | `true`               | Enable logging for the trail. Logs will be stored in the S3 bucket                                 | No       |
-| `s3_bucket_name`                 | ``                   | S3 bucket name for CloudTrail logs                                                                 | Yes (if `enable_logging`=`true`)  |
+| `s3_bucket_name`                 | ``                   | S3 bucket name for CloudTrail logs                                                                 | Yes (if `enable_logging` = `true`)  |
+| `cloud_watch_logs_role_arn`      | ``                   | Specifies the role for the CloudWatch Logs endpoint to assume to write to a user’s log group       | No       |
+| `cloud_watch_logs_group_arn`     | ``                   | Specifies a log group name using an Amazon Resource Name (ARN), that represents the log group to which CloudTrail logs will be delivered | No       |
+| `event_selector`                 | ``                   | Specifies an event selector for enabling data event logging. See: https://www.terraform.io/docs/providers/aws/r/cloudtrail.html for details on this map variable | No       |
+| `kms_key_id`                     | ``                   | Specifies the KMS key ARN to use to encrypt the logs delivered by CloudTrail                       | No        |
 
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "cloudtrail_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.3"
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.1.2"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"
@@ -18,6 +18,6 @@ resource "aws_cloudtrail" "default" {
   cloud_watch_logs_role_arn     = "${var.cloud_watch_logs_role_arn}"
   cloud_watch_logs_group_arn    = "${var.cloud_watch_logs_group_arn}"
   tags                          = "${module.cloudtrail_label.tags}"
-  event_selector                = "${var.event_selector}"
+  event_selector                = ["${var.event_selector}"]
   kms_key_id                    = "${var.kms_key_id}"
 }

--- a/main.tf
+++ b/main.tf
@@ -15,5 +15,9 @@ resource "aws_cloudtrail" "default" {
   enable_log_file_validation    = "${var.enable_log_file_validation}"
   is_multi_region_trail         = "${var.is_multi_region_trail}"
   include_global_service_events = "${var.include_global_service_events}"
+  cloud_watch_logs_role_arn     = "${var.cloud_watch_logs_role_arn}"
+  cloud_watch_logs_group_arn    = "${var.cloud_watch_logs_group_arn}"
   tags                          = "${module.cloudtrail_label.tags}"
+  event_selector                = "${var.event_selector}"
+  kms_key_id                    = "${var.kms_key_id}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -55,3 +55,24 @@ variable "s3_bucket_name" {
   type        = "string"
   description = "S3 bucket name for CloudTrail logs"
 }
+
+variable "cloud_watch_logs_role_arn" {
+  description = "Specifies the role for the CloudWatch Logs endpoint to assume to write to a user’s log group"
+  default     = ""
+}
+
+variable "cloud_watch_logs_group_arn" {
+  description = "Specifies a log group name using an Amazon Resource Name (ARN), that represents the log group to which CloudTrail logs will be delivered"
+  default     = ""
+}
+
+variable "event_selector" {
+  type        = "map"
+  description = "Specifies an event selector for enabling data event logging. See: https://www.terraform.io/docs/providers/aws/r/cloudtrail.html for details on this map variable"
+  default     = {}
+}
+
+variable "kms_key_id" {
+  description = "Specifies the KMS key ARN to use to encrypt the logs delivered by CloudTrail"
+  default     = ""
+}


### PR DESCRIPTION
## what
* Add missing resource fields
```
kms_key_id - (Optional) Specifies the KMS key ARN to use to encrypt the logs delivered by CloudTrail.
event_selector - (Optional) Specifies an event selector for enabling data event logging. Fields documented below. Please note the CloudTrail limits when configuring these.
cloud_watch_logs_role_arn - (Optional) Specifies the role for the CloudWatch Logs endpoint to assume to write to a user’s log group.
cloud_watch_logs_group_arn - (Optional) Specifies a log group name using an Amazon Resource Name (ARN), that represents the log group to which CloudTrail logs will be delivered.
```

## why
* Greater control over encryption and adds the ability to write to cloudwatch logs