### PR TITLE
Changed event selector to a list, so that it can be supplied as a list with a map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 *.tfstate.backup
 
 # Module directory
-.terraform/
+**/.terraform/
 .idea
 terraform-aws-cloudtrail.iml
 .build-harness

--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,6 @@ resource "aws_cloudtrail" "default" {
   cloud_watch_logs_role_arn     = "${var.cloud_watch_logs_role_arn}"
   cloud_watch_logs_group_arn    = "${var.cloud_watch_logs_group_arn}"
   tags                          = "${module.cloudtrail_label.tags}"
-  event_selector                = ["${var.event_selector}"]
+  event_selector                = "${var.event_selector}"
   kms_key_id                    = "${var.kms_key_id}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -67,9 +67,9 @@ variable "cloud_watch_logs_group_arn" {
 }
 
 variable "event_selector" {
-  type        = "map"
-  description = "Specifies an event selector for enabling data event logging. See: https://www.terraform.io/docs/providers/aws/r/cloudtrail.html for details on this map variable"
-  default     = {}
+  type        = "list"
+  description = "Specifies an event selector for enabling data event logging, It needs to be a list of map values. See: https://www.terraform.io/docs/providers/aws/r/cloudtrail.html for details on this map variable"
+  default     = []
 }
 
 variable "kms_key_id" {


### PR DESCRIPTION
What:
Change the event_selector var from a map to a list type.

Why:
It is currently a type map, that then gets put inside a list.
Even though it is a null map by default, because it is embedded into a list, it is evaluated by the cloudtrail resource.
And because it gets evaluated by the resource it triggers this bug:
https://github.com/terraform-providers/terraform-provider-aws/pull/5448

By switching it to a list, it means that by default instead of being a mull map in a null list, it is just a null list. Which is skipped over, and doesn't trigger the bug.


```
TF Apply with the Cloudtrail module always comes up with :

~ module.cloudtrail.aws_cloudtrail.default
     event_selector.#:                           "0" => "1"
     event_selector.0.include_management_events: "" => "true"
     event_selector.0.read_write_type:           "" => "All"
```