### PR TITLE
Update to terraform version 0.0.12

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -60,10 +60,10 @@ usage: |-
     namespace                     = "cp"
     stage                         = "dev"
     name                          = "cluster"
-    enable_log_file_validation    = "true"
-    include_global_service_events = "true"
-    is_multi_region_trail         = "false"
-    enable_logging                = "true"
+    enable_log_file_validation    = true
+    include_global_service_events = true
+    is_multi_region_trail         = false
+    enable_logging                = true
     s3_bucket_name                = "my-cloudtrail-logs-bucket"
   }
   ```
@@ -78,10 +78,10 @@ usage: |-
     namespace                     = "cp"
     stage                         = "dev"
     name                          = "cluster"
-    enable_log_file_validation    = "true"
-    include_global_service_events = "true"
-    is_multi_region_trail         = "false"
-    enable_logging                = "true"
+    enable_log_file_validation    = true
+    include_global_service_events = true
+    is_multi_region_trail         = false
+    enable_logging                = true
     s3_bucket_name                = "${module.cloudtrail_s3_bucket.bucket_id}"
   }
 

--- a/main.tf
+++ b/main.tf
@@ -1,26 +1,41 @@
 module "cloudtrail_label" {
   source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.1.2"
-  enabled    = "${var.enabled}"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  name       = "${var.name}"
-  delimiter  = "${var.delimiter}"
-  attributes = "${var.attributes}"
-  tags       = "${var.tags}"
+  enabled    = var.enabled
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = var.name
+  delimiter  = var.delimiter
+  attributes = var.attributes
+  tags       = var.tags
 }
 
 resource "aws_cloudtrail" "default" {
-  name                          = "${module.cloudtrail_label.id}"
-  count                         = "${var.enabled == "true" ? 1 : 0}"
-  enable_logging                = "${var.enable_logging}"
-  s3_bucket_name                = "${var.s3_bucket_name}"
-  enable_log_file_validation    = "${var.enable_log_file_validation}"
-  is_multi_region_trail         = "${var.is_multi_region_trail}"
-  include_global_service_events = "${var.include_global_service_events}"
-  cloud_watch_logs_role_arn     = "${var.cloud_watch_logs_role_arn}"
-  cloud_watch_logs_group_arn    = "${var.cloud_watch_logs_group_arn}"
-  tags                          = "${module.cloudtrail_label.tags}"
-  event_selector                = "${var.event_selector}"
-  kms_key_id                    = "${var.kms_key_id}"
-  is_organization_trail         = "${var.is_organization_trail}"
+  name                          = module.cloudtrail_label.id
+  count                         = var.enabled == true ? 1 : 0
+  enable_logging                = var.enable_logging
+  s3_bucket_name                = var.s3_bucket_name
+  enable_log_file_validation    = var.enable_log_file_validation
+  is_multi_region_trail         = var.is_multi_region_trail
+  include_global_service_events = var.include_global_service_events
+  cloud_watch_logs_role_arn     = var.cloud_watch_logs_role_arn
+  cloud_watch_logs_group_arn    = var.cloud_watch_logs_group_arn
+  tags                          = module.cloudtrail_label.tags
+  dynamic "event_selector" {
+    for_each = var.event_selector
+    content {
+
+      include_management_events = lookup(event_selector.value, "include_management_events", null)
+      read_write_type           = lookup(event_selector.value, "read_write_type", null)
+
+      dynamic "data_resource" {
+        for_each = lookup(event_selector.value, "data_resource", [])
+        content {
+          type   = data_resource.value.type
+          values = data_resource.value.values
+        }
+      }
+    }
+  }
+  kms_key_id            = var.kms_key_id
+  is_organization_trail = var.is_organization_trail
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,14 +1,15 @@
 output "cloudtrail_id" {
-  value       = "${join("", aws_cloudtrail.default.*.id)}"
+  value       = join("", aws_cloudtrail.default.*.id)
   description = "The name of the trail"
 }
 
 output "cloudtrail_home_region" {
-  value       = "${join("", aws_cloudtrail.default.*.home_region)}"
+  value       = join("", aws_cloudtrail.default.*.home_region)
   description = "The region in which the trail was created"
 }
 
 output "cloudtrail_arn" {
-  value       = "${join("", aws_cloudtrail.default.*.arn)}"
+  value       = join("", aws_cloudtrail.default.*.arn)
   description = "The Amazon Resource Name of the trail"
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -1,63 +1,63 @@
 variable "enabled" {
   description = "If true, deploy the resources for the module"
-  default     = "true"
+  default     = true
 }
 
 variable "namespace" {
   description = "Namespace (e.g. `cp` or `cloudposse`)"
-  type        = "string"
+  type        = string
 }
 
 variable "stage" {
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
-  type        = "string"
+  type        = string
 }
 
 variable "name" {
   description = "Name  (e.g. `app` or `cluster`)"
-  type        = "string"
+  type        = string
 }
 
 variable "delimiter" {
-  type        = "string"
+  type        = string
   default     = "-"
   description = "Delimiter to be used between `namespace`, `stage`, `name` and `attributes`"
 }
 
 variable "attributes" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "Additional attributes (e.g. `logs`)"
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "Additional tags (e.g. map('BusinessUnit`,`XYZ`)"
 }
 
 variable "enable_log_file_validation" {
-  default     = "true"
+  default     = true
   description = "Specifies whether log file integrity validation is enabled. Creates signed digest for validated contents of logs"
 }
 
 variable "is_multi_region_trail" {
-  default     = "false"
+  default     = false
   description = "Specifies whether the trail is created in the current region or in all regions"
 }
 
 variable "include_global_service_events" {
-  default     = "false"
+  default     = false
   description = "Specifies whether the trail is publishing events from global services such as IAM to the log files"
 }
 
 variable "enable_logging" {
-  default     = "true"
+  default     = true
   description = "Enable logging for the trail"
 }
 
 variable "s3_bucket_name" {
-  type        = "string"
+  type        = string
   description = "S3 bucket name for CloudTrail logs"
 }
 
@@ -72,7 +72,7 @@ variable "cloud_watch_logs_group_arn" {
 }
 
 variable "event_selector" {
-  type        = "list"
+  type        = list(string)
   description = "Specifies an event selector for enabling data event logging, It needs to be a list of map values. See: https://www.terraform.io/docs/providers/aws/r/cloudtrail.html for details on this map variable"
   default     = []
 }
@@ -83,6 +83,6 @@ variable "kms_key_id" {
 }
 
 variable "is_organization_trail" {
-  default     = "false"
+  default     = false
   description = "The trail is an AWS Organizations trail"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Changed the module to use version 0.0.12.

Note that this is breaking change as versions less than 0.0.12 can not under the syntax.

This change is required as the event selector in the 0.0.12 provider of  aws_cloudtrail expects a block.