### PR TITLE
Rename KMS key

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Available targets:
 | include_global_service_events | Specifies whether the trail is publishing events from global services such as IAM to the log files | string | `false` | no |
 | is_multi_region_trail | Specifies whether the trail is created in the current region or in all regions | string | `false` | no |
 | is_organization_trail | The trail is an AWS Organizations trail | string | `false` | no |
-| kms_key_id | Specifies the KMS key ARN to use to encrypt the logs delivered by CloudTrail | string | `` | no |
+| kms_key_arn | Specifies the KMS key ARN to use to encrypt the logs delivered by CloudTrail | string | `` | no |
 | name | Name  (e.g. `app` or `cluster`) | string | - | yes |
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
 | s3_bucket_name | S3 bucket name for CloudTrail logs | string | - | yes |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -13,7 +13,7 @@
 | include_global_service_events | Specifies whether the trail is publishing events from global services such as IAM to the log files | string | `false` | no |
 | is_multi_region_trail | Specifies whether the trail is created in the current region or in all regions | string | `false` | no |
 | is_organization_trail | The trail is an AWS Organizations trail | string | `false` | no |
-| kms_key_id | Specifies the KMS key ARN to use to encrypt the logs delivered by CloudTrail | string | `` | no |
+| kms_key_arn | Specifies the KMS key ARN to use to encrypt the logs delivered by CloudTrail | string | `` | no |
 | name | Name  (e.g. `app` or `cluster`) | string | - | yes |
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
 | s3_bucket_name | S3 bucket name for CloudTrail logs | string | - | yes |

--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,6 @@ resource "aws_cloudtrail" "default" {
   cloud_watch_logs_group_arn    = "${var.cloud_watch_logs_group_arn}"
   tags                          = "${module.cloudtrail_label.tags}"
   event_selector                = "${var.event_selector}"
-  kms_key_id                    = "${var.kms_key_id}"
+  kms_key_id                    = "${var.kms_key_arn}"
   is_organization_trail         = "${var.is_organization_trail}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -77,7 +77,7 @@ variable "event_selector" {
   default     = []
 }
 
-variable "kms_key_id" {
+variable "kms_key_arn" {
   description = "Specifies the KMS key ARN to use to encrypt the logs delivered by CloudTrail"
   default     = ""
 }


### PR DESCRIPTION
## What
* Rename `kms_key_id` to `kms_key_arn`

## Why
* To avoid confusing 