### PR TITLE
Rename KMS key

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Available targets:
 | include_global_service_events | Specifies whether the trail is publishing events from global services such as IAM to the log files | bool | `false` | no |
 | is_multi_region_trail | Specifies whether the trail is created in the current region or in all regions | bool | `false` | no |
 | is_organization_trail | The trail is an AWS Organizations trail | bool | `false` | no |
-| kms_key_id | Specifies the KMS key ARN to use to encrypt the logs delivered by CloudTrail | string | `` | no |
+| kms_key_arn | Specifies the KMS key ARN to use to encrypt the logs delivered by CloudTrail | string | `` | no |
 | name | Name  (e.g. `app` or `cluster`) | string | - | yes |
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | `` | no |
 | s3_bucket_name | S3 bucket name for CloudTrail logs | string | - | yes |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -13,7 +13,7 @@
 | include_global_service_events | Specifies whether the trail is publishing events from global services such as IAM to the log files | bool | `false` | no |
 | is_multi_region_trail | Specifies whether the trail is created in the current region or in all regions | bool | `false` | no |
 | is_organization_trail | The trail is an AWS Organizations trail | bool | `false` | no |
-| kms_key_id | Specifies the KMS key ARN to use to encrypt the logs delivered by CloudTrail | string | `` | no |
+| kms_key_arn | Specifies the KMS key ARN to use to encrypt the logs delivered by CloudTrail | string | `` | no |
 | name | Name  (e.g. `app` or `cluster`) | string | - | yes |
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | `` | no |
 | s3_bucket_name | S3 bucket name for CloudTrail logs | string | - | yes |

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ resource "aws_cloudtrail" "default" {
   cloud_watch_logs_role_arn     = var.cloud_watch_logs_role_arn
   cloud_watch_logs_group_arn    = var.cloud_watch_logs_group_arn
   tags                          = module.cloudtrail_label.tags
-  kms_key_id                    = var.kms_key_id
+  kms_key_id                    = var.kms_key_arn
   is_organization_trail         = var.is_organization_trail
 
   dynamic "event_selector" {

--- a/variables.tf
+++ b/variables.tf
@@ -95,7 +95,7 @@ variable "event_selector" {
   default     = []
 }
 
-variable "kms_key_id" {
+variable "kms_key_arn" {
   type        = string
   description = "Specifies the KMS key ARN to use to encrypt the logs delivered by CloudTrail"
   default     = ""


### PR DESCRIPTION
## What
* Rename `kms_key_id` to `kms_key_arn`

## Why
* To avoid confusing 