### PR TITLE
Add variable to disable default cloud posse tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ resource "aws_cloudtrail" "default" {
   include_global_service_events = var.include_global_service_events
   cloud_watch_logs_role_arn     = var.cloud_watch_logs_role_arn
   cloud_watch_logs_group_arn    = var.cloud_watch_logs_group_arn
-  tags                          = module.cloudtrail_label.tags
+  tags                          = var.cloud_posse_tags ? module.cloudtrail_label.tags : var.tags
   kms_key_id                    = var.kms_key_arn
   is_organization_trail         = var.is_organization_trail
 

--- a/variables.tf
+++ b/variables.tf
@@ -39,6 +39,12 @@ variable "tags" {
   description = "Additional tags (e.g. map('BusinessUnit`,`XYZ`)"
 }
 
+variable "cloud_posse_tags" {
+  type        = bool
+  default     = true
+  description = "Specifies whether tags should be enahnced with Cloud Posse defaults"
+}
+
 variable "enable_log_file_validation" {
   type        = bool
   default     = true


### PR DESCRIPTION
Thanks for this open source module, I'm planning to use it to setup CloudTrail logs for auditing.

I'm making this PR because in my project we have our own tag naming schema and that does not play well together with Cloud Posse's scheme. I understand if this change isn't really interesting for you, but I think it's a nice addition for people, like me, that want to use your modules without having extra tags being created on the resources.

I'm happy to accommodate any change you recommend, let me know.