### PR TITLE
Add terraform 0.13 support

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
     aws   = ">= 2.0"


### PR DESCRIPTION
## what
* Update the required Terraform version to add support for v0.13.x

## why
* Using this module with Terraform v0.13.x is not possible unless we update the required version
