### PR TITLE
Add sns_topic_name variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,18 @@ Available targets:
 |------|---------|
 | aws | >= 2.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| this | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -208,6 +220,7 @@ Available targets:
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | s3\_bucket\_name | S3 bucket name for CloudTrail logs | `string` | n/a | yes |
+| sns\_topic\_name | Specifies the name of the Amazon SNS topic defined for notification of log file delivery | `string` | `null` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 
@@ -218,7 +231,6 @@ Available targets:
 | cloudtrail\_arn | The Amazon Resource Name of the trail |
 | cloudtrail\_home\_region | The region in which the trail was created |
 | cloudtrail\_id | The name of the trail |
-
 <!-- markdownlint-restore -->
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -12,6 +12,18 @@
 |------|---------|
 | aws | >= 2.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| this | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -39,6 +51,7 @@
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | s3\_bucket\_name | S3 bucket name for CloudTrail logs | `string` | n/a | yes |
+| sns\_topic\_name | Specifies the name of the Amazon SNS topic defined for notification of log file delivery | `string` | `null` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 
@@ -49,5 +62,4 @@
 | cloudtrail\_arn | The Amazon Resource Name of the trail |
 | cloudtrail\_home\_region | The region in which the trail was created |
 | cloudtrail\_id | The name of the trail |
-
 <!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,7 @@ resource "aws_cloudtrail" "default" {
   enable_logging                = var.enable_logging
   s3_bucket_name                = var.s3_bucket_name
   enable_log_file_validation    = var.enable_log_file_validation
+  sns_topic_name                = var.sns_topic_name
   is_multi_region_trail         = var.is_multi_region_trail
   include_global_service_events = var.include_global_service_events
   cloud_watch_logs_role_arn     = var.cloud_watch_logs_role_arn

--- a/variables.tf
+++ b/variables.tf
@@ -65,3 +65,9 @@ variable "is_organization_trail" {
   default     = false
   description = "The trail is an AWS Organizations trail"
 }
+
+variable "sns_topic_name" {
+  type        = string
+  description = "Specifies the name of the Amazon SNS topic defined for notification of log file delivery"
+  default     = null
+}


### PR DESCRIPTION
## What

* Allow the user to optionally configure the sns_topic_name argument to the aws_cloudtrail resource

## Why

* We like using Cloudposse terraform modules, and would like to add one more input to the aws_cloudtrail resource in the form of a module variable.

## References

* [Resource documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail)
* [Conditionally omitted arguments](https://www.hashicorp.com/blog/terraform-0-12-conditional-operator-improvements)

